### PR TITLE
Downgrade Microsoft.Extensions.Logging to 2.0.0

### DIFF
--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -41,7 +41,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="microsoft.extensions.logging" Version="2.2.0" />
+    <PackageReference Include="microsoft.extensions.logging" Version="2.0.0" />
     <PackageReference Include="rebus" Version="4.0.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">


### PR DESCRIPTION
This project does not depend on any 2.2.0 specific features. Hence,
downgrading the package to enable safe use for the ones bound by the LTS
version of .NET Core (2.1 as of October 2019).

Resolves #2

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
