### PR TITLE
Upgrade Rebus dependency to 6.1 and aspnet.core in a sample application to 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@
 
 ## 1.0.1
 * Downgrade Microsoft.Extensions.Logging dependency to version 2.0.0, because there's no need to REQUIRE 2.2.0
+
+## 2.0.0
+* Upgrade Rebus dependency to 6.1 and aspnet.core in a sample application to 3.1

--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -42,8 +42,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="microsoft.extensions.logging" Version="2.0.0" />
-    <PackageReference Include="rebus" Version="4.0.0" />
+    <PackageReference Include="microsoft.extensions.logging" Version="3.1.3" />
+    <PackageReference Include="rebus" Version="6.1.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -10,19 +10,16 @@ namespace TestApp
     {
         static void Main()
         {
-            var loggerFactory = new LoggerFactory()
-                .AddConsole();
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
-            using (var activator = new BuiltinHandlerActivator())
-            {
-                Configure.With(activator)
-                    .Logging(l => l.MicrosoftExtensionsLogging(loggerFactory))
-                    .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "logging-test"))
-                    .Start();
+            using var activator = new BuiltinHandlerActivator();
+            Configure.With(activator)
+                .Logging(l => l.MicrosoftExtensionsLogging(loggerFactory))
+                .Transport(t => t.UseInMemoryTransport(new InMemNetwork(), "logging-test"))
+                .Start();
 
-                Console.WriteLine("Press ENTER to quit");
-                Console.ReadLine();
-            }
+            Console.WriteLine("Press ENTER to quit");
+            Console.ReadLine();
         }
     }
 }

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="rebus" Version="4.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
+    <PackageReference Include="rebus" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION


---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
