### PR TITLE
Adding support for NET 5.0

### DIFF
--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus</RootNamespace>
     <AssemblyName>Rebus.Microsoft.Extensions.Logging</AssemblyName>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+   <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
@@ -42,9 +42,22 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="microsoft.extensions.logging" Version="3.1.3" />
-    <PackageReference Include="rebus" Version="6.1.0" />
+    <PackageReference Include="rebus" Version="[6.1.0,)" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="microsoft.extensions.logging" Version="[2.0.0,3)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <PackageReference Include="microsoft.extensions.logging" Version="[3.0.0,5)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="microsoft.extensions.logging" Version="[5.0.0-rc.2.20475.5,6)" />
+  </ItemGroup>
+
+
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />
   </Target>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
