### PR TITLE
Upped nugets for logging and rebus itself to support net6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ _ReSharper.*
 _NCrunch_*
 *.user
 *.backup
+.idea
+.idea/*
 
 # MS Guideline
 **/packages/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,7 @@
 ## 2.0.0
 * Upgrade Rebus dependency to 6.1 and aspnet.core in a sample application to 3.1 - thanks [rsivanov]
 
+## 3.0.0
+* Upgrade Rebus dependency to 6.6.5 and aspnet.core in a sample application to 6.0 - thanks [dannythunder]
+
 [rsivanov]: https://github.com/rsivanov

--- a/Rebus.Microsoft.Extensions.Logging/Properties/AssemblyInfo.cs
+++ b/Rebus.Microsoft.Extensions.Logging/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Rebus.Microsoft.Extensions.Logging")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
+[assembly: AssemblyCopyright("Copyright © 2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus</RootNamespace>
     <AssemblyName>Rebus.Microsoft.Extensions.Logging</AssemblyName>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
     <PackageProjectUrl>https://rebus.fm/what-is-rebus/</PackageProjectUrl>
-    <Copyright>Copyright 2012-2016</Copyright>
+    <Copyright>Copyright 2012-2022</Copyright>
     <PackageTags>rebus microsoft extensions logging</PackageTags>
     <PackageIconUrl>https://github.com/mookid8000/Rebus/raw/master/artwork/little_rebusbus2_copy-200x200.png</PackageIconUrl>
     <PackageDescription>Microsoft.Extensions.Logging-based logging integration for Rebus</PackageDescription>
@@ -42,8 +42,8 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="microsoft.extensions.logging" Version="3.1.3" />
-    <PackageReference Include="rebus" Version="6.1.0" />
+    <PackageReference Include="microsoft.extensions.logging" Version="[6.0.0, 7.0.0)" />
+    <PackageReference Include="rebus" Version="6.6.5" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />

--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus</RootNamespace>
     <AssemblyName>Rebus.Microsoft.Extensions.Logging</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
-    <PackageReference Include="rebus" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="rebus" Version="6.6.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
First PR was based on a 3.0.0 branch, this is based on master

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
