### PR TITLE
Removed package constraints for Microsoft.Extensions.Logging

### DIFF
--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -24,10 +24,7 @@
 	<ItemGroup>
 		<PackageReference Include="rebus" Version="6.6.5" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="microsoft.extensions.logging" Version="[6,7)" />
-	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-		<PackageReference Include="microsoft.extensions.logging" Version="[7,8)" />
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 	</ItemGroup>
 </Project>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -2,13 +2,13 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-		<PackageReference Include="rebus" Version="6.6.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+		<PackageReference Include="rebus" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
As specified in the issue #10 , i am getting the warnings:

```
warning NU1608: Detected package version outside of dependency constraint: 
Rebus.Microsoft.Extensions.Logging 3.0.0 requires microsoft.extensions.logging (>= 6.0.0 && < 7.0.0) 
but version Microsoft.Extensions.Logging 7.0.0 was resolved. [TargetFramework=net6.0]
```

```
warning NU1608: Detected package version outside of dependency constraint: 
Rebus.Microsoft.Extensions.Logging 3.0.0 requires microsoft.extensions.logging (>= 6.0.0 && < 7.0.0) 
but version Microsoft.Extensions.Logging 7.0.0 was resolved. [TargetFramework=net7.0]
```

This pull request removes the constraints and uses the latest Microsoft.Extensions.Logging package, according to nuget this should still respect the version constraints:

![image](https://user-images.githubusercontent.com/7645736/217520694-290a5400-1af0-4f5e-9419-53293a9dcdca.png)



---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
