### PR TITLE
Add support for .NET 9

### DIFF
--- a/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
+++ b/Rebus.Microsoft.Extensions.Logging/Rebus.Microsoft.Extensions.Logging.csproj
@@ -27,7 +27,7 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="rebus" Version="8.0.1" />
-		<PackageReference Include="microsoft.extensions.logging.abstractions" Version="[6.0.0, 9)" />
+		<PackageReference Include="Rebus" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[6.0.0, 10)" />
 	</ItemGroup>
 </Project>

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -1,17 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="rebus" Version="8.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+		<PackageReference Include="Rebus" Version="8.0.1" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Rebus.Microsoft.Extensions.Logging\Rebus.Microsoft.Extensions.Logging.csproj" />
 	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
This extends the upper dependency version limit to allow .NET 9 packages, fixing https://github.com/rebus-org/Rebus.ServiceProvider/issues/95.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
